### PR TITLE
Add Docker deployment configuration for orchestrator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.10-slim
+
+WORKDIR /app
+
+# Install system dependencies
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends bash \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Python dependencies
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application source
+COPY aplicatie_web/ ./aplicatie_web/
+
+EXPOSE 5000
+
+CMD ["python", "aplicatie_web/app.py"]

--- a/README.md
+++ b/README.md
@@ -55,6 +55,18 @@ Pentru a porni aplicația fără instalarea serviciului systemd:
 python3 aplicatie_web/app.py
 ```
 
+## Docker
+
+Aplicația poate fi rulată în containere Docker, inclusiv pe Windows prin Docker Desktop.
+
+1. Instalează [Docker Desktop](https://www.docker.com/products/docker-desktop/).
+2. Din directorul proiectului rulează:
+   ```bash
+   docker compose up --build
+   ```
+
+Acest comandă va construi imaginea **mildocdms-orchestrator**, va porni containerul cu același nume pe portul `5000` și îl va conecta la serviciul `mildocdms` definit în `docker-compose.yml`.
+
 ## Instalare offline a dependențelor
 
 1. Asigurați-vă că aveți instalate `python3` și `pip`:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3.8'
+services:
+  mildocdms:
+    image: mildocdms:latest
+    container_name: mildocdms
+    ports:
+      - "8000:8000"
+
+  orchestrator:
+    build: .
+    container_name: mildocdms-orchestrator
+    ports:
+      - "5000:5000"
+    depends_on:
+      - mildocdms
+    environment:
+      - MILDOC_SERVICE_URL=http://mildocdms:8000


### PR DESCRIPTION
## Summary
- add Python-based Dockerfile for web console
- include docker-compose for orchestrator and mildocdms
- document Docker workflow for Docker Desktop users

## Testing
- `python -m py_compile aplicatie_web/*.py`
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ac034aaea883299aef03b421ed4e9b