### PR TITLE
feat: run orchestrator container independently

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.10-slim
+
+WORKDIR /app
+
+# Install system dependencies
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends bash \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Python dependencies
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application source
+COPY aplicatie_web/ ./aplicatie_web/
+
+EXPOSE 5000
+
+CMD ["python", "aplicatie_web/app.py"]

--- a/README.md
+++ b/README.md
@@ -55,6 +55,25 @@ Pentru a porni aplicația fără instalarea serviciului systemd:
 python3 aplicatie_web/app.py
 ```
 
+## Docker
+
+Aplicația poate fi rulată în containere Docker, inclusiv pe Windows prin Docker Desktop. Asigură-te că serviciul `mildocdms` rulează separat și expune portul `8000` (ex.: `docker run -p 8000:8000 --name mildocdms mildocdms:latest`).
+
+1. Instalează [Docker Desktop](https://www.docker.com/products/docker-desktop/).
+2. Din directorul proiectului rulează:
+   ```bash
+   docker compose up --build
+   ```
+
+Această comandă construiește imaginea **mildocdms-orchestrator** și pornește containerul cu același nume pe portul `5000`. Containerul se conectează la serviciul `mildocdms` prin `http://host.docker.internal:8000`.
+
+Alternativ, poți construi și rula manual:
+
+```bash
+docker build -t mildocdms-orchestrator .
+docker run -p 5000:5000 -e MILDOC_SERVICE_URL=http://host.docker.internal:8000 mildocdms-orchestrator
+```
+
 ## Instalare offline a dependențelor
 
 1. Asigurați-vă că aveți instalate `python3` și `pip`:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.8'
+services:
+  orchestrator:
+    build: .
+    container_name: mildocdms-orchestrator
+    ports:
+      - "5000:5000"
+    environment:
+      - MILDOC_SERVICE_URL=http://host.docker.internal:8000


### PR DESCRIPTION
## Summary
- remove mildocdms service from compose file and point orchestrator to host.docker.internal
- document how to build and run the mildocdms-orchestrator image alongside an existing mildocdms container

## Testing
- `python -m py_compile aplicatie_web/*.py`
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ac034aaea883299aef03b421ed4e9b